### PR TITLE
Add ssh_key_fingerprint to cookiecutter.json

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,5 +1,6 @@
 {
     "project_slug": "{{ cookiecutter.project_name|lower|replace(' ', '')|replace('-', '_') }}",
     "project_dash_slug": "{{ cookiecutter.project_slug|replace('_', '-') }}",
-    "owner_email": "{{ cookiecutter.owner_email }}"
+    "owner_email": "{{ cookiecutter.owner_email }}",
+    "ssh_key_fingerprint": "{{ cookiecutter.ssh_key_fingerprint }}"
 }

--- a/{{cookiecutter.project_slug}}/.circleci/config.yml
+++ b/{{cookiecutter.project_slug}}/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
     steps:
       - add_ssh_keys:
           fingerprints:
-            - "{{cookiecutter.ssh_key_fingerprint}}"
+            - "{{ cookiecutter.ssh_key_fingerprint }}"
 
       - checkout
 


### PR DESCRIPTION
This adds the missing fingerprint var. I'm not sure if this file is getting processed correctly by cookiecutter so it may need one more PR.