### PR TITLE
Change raw escape in circle config

### DIFF
--- a/{{cookiecutter.project_slug}}/.circleci/config.yml
+++ b/{{cookiecutter.project_slug}}/.circleci/config.yml
@@ -105,8 +105,9 @@ jobs:
     steps:
       - add_ssh_keys:
           fingerprints:
+{% endraw %}
             - "{{ cookiecutter.ssh_key_fingerprint }}"
-
+{% raw %}
       - checkout
 
       - run:


### PR DESCRIPTION
This should fix the ssh_key_fingerprint var.