### PR TITLE
Add ITSAppUsesNonExemptEncryption to allow auto deploy to testflight

### DIFF
--- a/{{cookiecutter.project_slug}}/ios/{{cookiecutter.project_slug}}-tvOS/Info.plist
+++ b/{{cookiecutter.project_slug}}/ios/{{cookiecutter.project_slug}}-tvOS/Info.plist
@@ -49,6 +49,7 @@
 				<true/>
 			</dict>
 		</dict>
-	</dict>
+  </dict>
+  <key>ITSAppUsesNonExemptEncryption</key><false/>
 </dict>
 </plist>

--- a/{{cookiecutter.project_slug}}/ios/{{cookiecutter.project_slug}}/Info.plist
+++ b/{{cookiecutter.project_slug}}/ios/{{cookiecutter.project_slug}}/Info.plist
@@ -55,6 +55,7 @@
 				<true/>
 			</dict>
 		</dict>
-	</dict>
+  </dict>
+  <key>ITSAppUsesNonExemptEncryption</key><false/>
 </dict>
 </plist>


### PR DESCRIPTION
Without this key App Store Connect sometimes requires user input to deploy to testflight.