### PR TITLE
Fix missing whitespace before checkout

### DIFF
--- a/{{cookiecutter.project_slug}}/.circleci/config.yml
+++ b/{{cookiecutter.project_slug}}/.circleci/config.yml
@@ -109,8 +109,7 @@ jobs:
           fingerprints:
 {%- endraw %}
             - "{{ cookiecutter.ssh_key_fingerprint }}"
-{% raw -%}
-
+{% raw %}
       - checkout
 
       - run:


### PR DESCRIPTION
I misunderstood how adding a `-` to `{% raw %}` works. It removes all whitespace between the tag and the next non-whitespace character. I thought it only removed whitespace on that line.