### PR TITLE
Remove *.keystore from .gitignore

### DIFF
--- a/{{cookiecutter.project_slug}}/.gitignore
+++ b/{{cookiecutter.project_slug}}/.gitignore
@@ -38,7 +38,6 @@ yarn-error.log
 # BUCK
 buck-out/
 \.buckd/
-*.keystore
 
 # fastlane
 #


### PR DESCRIPTION
This makes sure the `debug.keystore` is not being removed on the scaffold process.