### PR TITLE
PLAT-1103: Check HAS_PAID_PLAN env var before building iOS

### DIFF
--- a/{{cookiecutter.project_slug}}/.circleci/config.yml
+++ b/{{cookiecutter.project_slug}}/.circleci/config.yml
@@ -121,8 +121,13 @@ jobs:
       - checkout
 
       - run:
+          name: Check if app has a paid plan
+          command: |
+            [ "$HAS_PAID_PLAN" != 1 ] && exit 1
+
+      - run:
           name: set Ruby version
-          command:  echo "ruby-2.5" > ~/.ruby-version
+          command: echo "ruby-2.5" > ~/.ruby-version
 
       - restore_cache:
           key: yarn-v1-{{ checksum "yarn.lock" }}-{{ arch }}
@@ -180,7 +185,6 @@ jobs:
       - run:
           name: Set up test results
           working_directory: ios
-          when: always
           command: |
             mkdir -p test-results/fastlane test-results/xcode
             mv fastlane/report.xml test-results/fastlane

--- a/{{cookiecutter.project_slug}}/.circleci/config.yml
+++ b/{{cookiecutter.project_slug}}/.circleci/config.yml
@@ -123,7 +123,9 @@ jobs:
       - run:
           name: Check if app has a paid plan
           command: |
-            [ "$HAS_PAID_PLAN" != 1 ] && exit 1
+            if [ "$HAS_PAID_PLAN" != 1 ]; then
+              exit 1
+            fi
 
       - run:
           name: set Ruby version

--- a/{{cookiecutter.project_slug}}/.circleci/webhook_callback.sh
+++ b/{{cookiecutter.project_slug}}/.circleci/webhook_callback.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+# Ignore iOS error if there is no paid plan
+if [ "$CIRCLE_JOB" == "ios" ] && [ "$HAS_PAID_PLAN" != 1 ]; then
+  exit
+fi
+
 set -euo pipefail
 
 # Script based on https://altinukshini.wordpress.com/2019/01/09/circleci-notifications-in-rocketchat/

--- a/{{cookiecutter.project_slug}}/.circleci/webhook_callback.sh
+++ b/{{cookiecutter.project_slug}}/.circleci/webhook_callback.sh
@@ -2,6 +2,7 @@
 
 # Ignore iOS error if there is no paid plan
 if [ "$CIRCLE_JOB" == "ios" ] && [ "$HAS_PAID_PLAN" != 1 ]; then
+  echo "No paid plan, not calling webhook"
   exit
 fi
 
@@ -27,3 +28,4 @@ EOM
 )
 
 curl -X POST -H "Content-Type: application/json" -H "Authorization: Api-Key $WEBHOOK_API_KEY" --data "$payload" $url
+echo "Webhook call completed"


### PR DESCRIPTION
## Ticket

[PLAT-1103](https://crowdbotics.atlassian.net/browse/PLAT-1103)
_Related tickets:_ https://github.com/crowdbotics/crowdbotics-slack-app/pull/1720 (required before this is merged)

## Type of PR

- [ ] Bugfix
- [x] New feature
- [ ] Minor changes

## Changes introduced

This checks the `HAS_PAID_PLAN` env var on circle when a project is deployed. The circle config can then use that variable to take different actions for paid and free apps.

This requires [#1720](https://github.com/crowdbotics/crowdbotics-slack-app/pull/1720) before it can be merged and tested. Without that PR this will cause all iOS builds to fail regardless of plan.

## Known Issues

This depends on the circle config to check for a plan. Users can edit this config, allowing them to build iOS without a plan. We will have to come up with a better solution in the future to avoid this problem. It will likely be a more complex solution.

## Test and review

1. Deploy a free mobile project. Only Android should build.
2. Add a plan and deploy again. Both Android and iOS should build.
