### PR TITLE
PLAT-4028: upgrade ui-kitten to 4.4.1

### DIFF
--- a/{{cookiecutter.project_slug}}/package.json
+++ b/{{cookiecutter.project_slug}}/package.json
@@ -12,7 +12,7 @@
     "preset": "react-native"
   },
   "dependencies": {
-    "@eva-design/eva": "2.0.0",
+    "@eva-design/eva": "^1.4.0",
     "@fortawesome/fontawesome-svg-core": "1.2.22",
     "@fortawesome/free-solid-svg-icons": "5.13.0",
     "@fortawesome/react-native-fontawesome": "0.2.5",
@@ -33,7 +33,7 @@
     "react-native-reanimated": "1.9.0",
     "react-native-screens": "1.0.0-alpha.22",
     "react-native-svg": "9.13.6",
-    "react-native-ui-kitten": "4.3.2",
+    "react-native-ui-kitten": "^4.4.1",
     "react-native-vector-icons": "^6.6.0",
     "react-navigation": "4.0.10",
     "react-navigation-stack": "1.10.3",


### PR DESCRIPTION
UI kitten 5.0 contains lots of breaking changes. 
https://akveo.github.io/react-native-ui-kitten/docs/migration/4x500-migration#4x--500-ui-kitten-migration

this 5.0 upgrade will be big effort, so temporarily upgrade to latest 4.x (4.4.1). It support calendar or Datepicker component (Date Input)


