### PR TITLE
add keystore file  step  on android job

### DIFF
--- a/{{cookiecutter.project_slug}}/.circleci/config.yml
+++ b/{{cookiecutter.project_slug}}/.circleci/config.yml
@@ -91,6 +91,13 @@ jobs:
           command: env >> .env
 
       - run:
+          name: Add upload-key.keystore file
+          working_directory: android
+          command:  |
+            cd app
+            echo "$ANDROID_KEYSTORE" | base64 --decode > upload-key.keystore
+
+      - run:
           name: Build and upload to appetize.io
           command: bundle exec fastlane deploy_appetize
           working_directory: android


### PR DESCRIPTION
This PR add the upload-key.keystore file to android. 
This should be merged after the PR https://github.com/crowdbotics/crowdbotics-slack-app/pull/2436 is merged.