### PR TITLE
PLAT-5165: Fix failing android builds

### DIFF
--- a/{{cookiecutter.project_slug}}/android/fastlane/Fastfile
+++ b/{{cookiecutter.project_slug}}/android/fastlane/Fastfile
@@ -107,7 +107,7 @@ def get_appetize_public_key(platform, base_name)
     app_app['note'] == base_name && app_app['platform'] == platform
   end
 
-  item['publicKey']
+  item['publicKey'] if item
 end
 
 def get_last_apk_path

--- a/{{cookiecutter.project_slug}}/ios/fastlane/Fastfile
+++ b/{{cookiecutter.project_slug}}/ios/fastlane/Fastfile
@@ -160,9 +160,8 @@ platform(:ios) do
 end
 
 def get_appetize_public_key(platform, base_name)
-  @appetize_key ||= ENV['APPETIZE_PUBLIC_KEY']
-  @appetize_key ||= fetch_appetize_public_key(platform, base_name)
-  @appetize_key
+  appetize_key = ENV['APPETIZE_PUBLIC_KEY']
+  appetize_key ||= fetch_appetize_public_key(platform, base_name)
 end
 
 def fetch_appetize_public_key(platform, base_name)


### PR DESCRIPTION
If `item` wasn't found attempting to access `item['publicKey']` was throwing an exception. I also cleaned up the iOS implementation of `get_appetize_public_key`, changing `appetize_key` from an unnecessary class var to a local var.