### PR TITLE
Enable UseCGroupMemoryLimitForHeap JDK option

### DIFF
--- a/{{cookiecutter.project_slug}}/.circleci/config.yml
+++ b/{{cookiecutter.project_slug}}/.circleci/config.yml
@@ -5,6 +5,8 @@ jobs:
     working_directory: ~/build
     docker:
       - image: circleci/node:10
+    environment:
+      - _JAVA_OPTIONS: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
     steps:
       - checkout
 


### PR DESCRIPTION
This prevents OOM errors while building. Based on React-Native setup here:
https://github.com/facebook/react-native/blob/d368d11a0fed7fb09dc44fccc97f2f18cd85cdf2/.circleci/config.yml#L43