### PR TITLE
Remove extra spaces that prevents building the app

### DIFF
--- a/{{cookiecutter.project_slug}}/src/store/custom/sagas.js
+++ b/{{cookiecutter.project_slug}}/src/store/custom/sagas.js
@@ -29,7 +29,7 @@ export default function* customRootSaga() {
   ]
   yield all(
     sagas.map(saga =>
-      spawn(function* () {
+      spawn(function*() {
         while (true) {
           try {
             yield call(saga)

--- a/{{cookiecutter.project_slug}}/src/store/sagas.js
+++ b/{{cookiecutter.project_slug}}/src/store/sagas.js
@@ -10,7 +10,7 @@ export default function* rootSaga() {
   ]
   yield all(
     sagas.map(saga =>
-      spawn(function* () {
+      spawn(function*() {
         while (true) {
           try {
             yield call(saga)


### PR DESCRIPTION
This fixes some style issues that block running `yarn web-build`. Without this change prettier prevents the build from running.