### PR TITLE
add missing @components alias to webpack.config.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Based on [Common Changelog](https://common-changelog.org/).
 
+## 2.5.2 - 2023-11-02
+
+### Fixed
+
+- added `@components` alias to `webpack.config.js`- this alias was missing
+
 ## 2.5.1 - 2023-11-02
 
 ### Fixed

--- a/dist/cookie/{{cookiecutter.project_slug}}/.crowdbotics.json
+++ b/dist/cookie/{{cookiecutter.project_slug}}/.crowdbotics.json
@@ -1,7 +1,7 @@
 {
   "scaffold": {
     "type": "react-native",
-    "version": "2.5.1",
+    "version": "2.5.2",
     "cookiecutter_context": {
       "project_name": "{{cookiecutter.project_name}}",
       "project_slug": "{{cookiecutter.project_slug}}",

--- a/dist/cookie/{{cookiecutter.project_slug}}/webpack.config.js
+++ b/dist/cookie/{{cookiecutter.project_slug}}/webpack.config.js
@@ -142,7 +142,8 @@ module.exports = {
       "@modules": path.resolve(appDirectory, "modules"),
       "@screens": path.resolve(appDirectory, "screens"),
       "@options": path.resolve(appDirectory, "options"),
-      "@store": path.resolve(appDirectory, "store")
+      "@store": path.resolve(appDirectory, "store"),
+      "@components": path.resolve(appDirectory, "components")
     },
     // If you're working on a multi-platform React Native app, web-specific
     // module implementations should be written in files using the extension

--- a/scaffold/package.json
+++ b/scaffold/package.json
@@ -1,6 +1,6 @@
 {
   "name": "template",
   "description": "React Native Template",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "author": "Crowdbotics"
 }

--- a/scaffold/template/custom/.crowdbotics.json
+++ b/scaffold/template/custom/.crowdbotics.json
@@ -1,7 +1,7 @@
 {
   "scaffold": {
     "type": "react-native",
-    "version": "2.5.1",
+    "version": "2.5.2",
     "cookiecutter_context": {
       "project_name": "{{cookiecutter.project_name}}",
       "project_slug": "{{cookiecutter.project_slug}}",

--- a/scaffold/template/custom/webpack.config.js
+++ b/scaffold/template/custom/webpack.config.js
@@ -142,7 +142,8 @@ module.exports = {
       "@modules": path.resolve(appDirectory, "modules"),
       "@screens": path.resolve(appDirectory, "screens"),
       "@options": path.resolve(appDirectory, "options"),
-      "@store": path.resolve(appDirectory, "store")
+      "@store": path.resolve(appDirectory, "store"),
+      "@components": path.resolve(appDirectory, "components")
     },
     // If you're working on a multi-platform React Native app, web-specific
     // module implementations should be written in files using the extension


### PR DESCRIPTION
Did you make changes to the scaffold?

- [x] Yes, and have read the [scaffold updates checklist](https://github.com/crowdbotics/react-native-scaffold/#scaffold-updates-checklist) documentation and followed the instructions.

## Changes introduced

Added `@components` alias to `webpack.config.js` to match metro's config.

## Test and review

Importing from `@components` should work both on web and mobile builds.
