### PR TITLE
add `@helpers` alias and responsive design hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Based on [Common Changelog](https://common-changelog.org/).
 
+## 2.6.0 - 2023-11-14
+
+### Added
+
+Added new `helpers` directory and `@helpers` alias on `webpack.config.js` and `metro.config.js`.
+
+The `index.js` includes two new helper hooks for building responsive designs:
+- `useComponentLayout` - custom hook for the `onLayout` prop callback - useful for measuring individual elements on resize
+- `useMatchMedia` - custom hook that abstracts the `window.matchMedia` Web API
+
 ## 2.5.2 - 2023-11-02
 
 ### Fixed

--- a/dist/cookie/{{cookiecutter.project_slug}}/.crowdbotics.json
+++ b/dist/cookie/{{cookiecutter.project_slug}}/.crowdbotics.json
@@ -1,7 +1,7 @@
 {
   "scaffold": {
     "type": "react-native",
-    "version": "2.5.2",
+    "version": "2.6.0",
     "cookiecutter_context": {
       "project_name": "{{cookiecutter.project_name}}",
       "project_slug": "{{cookiecutter.project_slug}}",

--- a/dist/cookie/{{cookiecutter.project_slug}}/helpers/index.js
+++ b/dist/cookie/{{cookiecutter.project_slug}}/helpers/index.js
@@ -1,0 +1,38 @@
+import { useState, useCallback, useEffect } from "react"
+
+/**
+ * Get the layout values for the current component, and the callback for updating it.
+ *
+ * @function
+ * @returns {Array.<Object>}
+ */
+export function useComponentLayout() {
+  const [layout, setLayout] = useState({})
+
+  const onLayout = useCallback(event => {
+    setLayout(event.nativeEvent.layout)
+  }, [])
+
+  return [layout, onLayout]
+}
+
+/**
+ * Use media queries via the matchMedia Web API. Web only.
+ *
+ * @function
+ * @param {string} query
+ * @returns {boolean}
+ */
+export const useMatchMedia = query => {
+  if (!window) throw new Error("useMatchMedia can only be used on web")
+  const mediaMatch = window.matchMedia(query)
+  const [matches, setMatches] = useState(mediaMatch.matches)
+
+  useEffect(() => {
+    const handler = e => setMatches(e.matches)
+    mediaMatch.addListener(handler)
+    return () => mediaMatch.removeListener(handler)
+  }, [])
+
+  return matches
+}

--- a/dist/cookie/{{cookiecutter.project_slug}}/metro.config.js
+++ b/dist/cookie/{{cookiecutter.project_slug}}/metro.config.js
@@ -11,7 +11,8 @@ const extraNodeModules = {
   "@modules": path.resolve(__dirname, "modules"),
   "@screens": path.resolve(__dirname, "screens"),
   "@options": path.resolve(__dirname, "options"),
-  "@store": path.resolve(__dirname, "store")
+  "@store": path.resolve(__dirname, "store"),
+  "@helpers": path.resolve(__dirname, "helpers")
 }
 
 const watchFolders = [
@@ -19,7 +20,8 @@ const watchFolders = [
   path.resolve(__dirname, "modules"),
   path.resolve(__dirname, "screens"),
   path.resolve(__dirname, "options"),
-  path.resolve(__dirname, "store")
+  path.resolve(__dirname, "store"),
+  path.resolve(__dirname, "helpers")
 ]
 
 module.exports = {

--- a/dist/cookie/{{cookiecutter.project_slug}}/webpack.config.js
+++ b/dist/cookie/{{cookiecutter.project_slug}}/webpack.config.js
@@ -143,7 +143,8 @@ module.exports = {
       "@screens": path.resolve(appDirectory, "screens"),
       "@options": path.resolve(appDirectory, "options"),
       "@store": path.resolve(appDirectory, "store"),
-      "@components": path.resolve(appDirectory, "components")
+      "@components": path.resolve(appDirectory, "components"),
+      "@helpers": path.resolve(appDirectory, "helpers")
     },
     // If you're working on a multi-platform React Native app, web-specific
     // module implementations should be written in files using the extension

--- a/scaffold/install.js
+++ b/scaffold/install.js
@@ -20,6 +20,7 @@ fs.renameSync(path.join(customFiles, "modules"), path.join(cwd, "modules"));
 fs.renameSync(path.join(customFiles, "screens"), path.join(cwd, "screens"));
 fs.renameSync(path.join(customFiles, "options"), path.join(cwd, "options"));
 fs.renameSync(path.join(customFiles, "store"), path.join(cwd, "store"));
+fs.renameSync(path.join(customFiles, "helpers"), path.join(cwd, "helpers"));
 fs.renameSync(path.join(customFiles, "public"), path.join(cwd, "public"));
 
 // CircleCI

--- a/scaffold/package.json
+++ b/scaffold/package.json
@@ -1,6 +1,6 @@
 {
   "name": "template",
   "description": "React Native Template",
-  "version": "2.5.2",
+  "version": "2.6.0",
   "author": "Crowdbotics"
 }

--- a/scaffold/template/custom/.crowdbotics.json
+++ b/scaffold/template/custom/.crowdbotics.json
@@ -1,7 +1,7 @@
 {
   "scaffold": {
     "type": "react-native",
-    "version": "2.5.2",
+    "version": "2.6.0",
     "cookiecutter_context": {
       "project_name": "{{cookiecutter.project_name}}",
       "project_slug": "{{cookiecutter.project_slug}}",

--- a/scaffold/template/custom/helpers/index.js
+++ b/scaffold/template/custom/helpers/index.js
@@ -1,0 +1,38 @@
+import { useState, useCallback, useEffect } from "react"
+
+/**
+ * Get the layout values for the current component, and the callback for updating it.
+ *
+ * @function
+ * @returns {Array.<Object>}
+ */
+export function useComponentLayout() {
+  const [layout, setLayout] = useState({})
+
+  const onLayout = useCallback(event => {
+    setLayout(event.nativeEvent.layout)
+  }, [])
+
+  return [layout, onLayout]
+}
+
+/**
+ * Use media queries via the matchMedia Web API. Web only.
+ *
+ * @function
+ * @param {string} query
+ * @returns {boolean}
+ */
+export const useMatchMedia = query => {
+  if (!window) throw new Error("useMatchMedia can only be used on web")
+  const mediaMatch = window.matchMedia(query)
+  const [matches, setMatches] = useState(mediaMatch.matches)
+
+  useEffect(() => {
+    const handler = e => setMatches(e.matches)
+    mediaMatch.addListener(handler)
+    return () => mediaMatch.removeListener(handler)
+  }, [])
+
+  return matches
+}

--- a/scaffold/template/custom/metro.config.js
+++ b/scaffold/template/custom/metro.config.js
@@ -11,7 +11,8 @@ const extraNodeModules = {
   "@modules": path.resolve(__dirname, "modules"),
   "@screens": path.resolve(__dirname, "screens"),
   "@options": path.resolve(__dirname, "options"),
-  "@store": path.resolve(__dirname, "store")
+  "@store": path.resolve(__dirname, "store"),
+  "@helpers": path.resolve(__dirname, "helpers")
 }
 
 const watchFolders = [
@@ -19,7 +20,8 @@ const watchFolders = [
   path.resolve(__dirname, "modules"),
   path.resolve(__dirname, "screens"),
   path.resolve(__dirname, "options"),
-  path.resolve(__dirname, "store")
+  path.resolve(__dirname, "store"),
+  path.resolve(__dirname, "helpers")
 ]
 
 module.exports = {

--- a/scaffold/template/custom/webpack.config.js
+++ b/scaffold/template/custom/webpack.config.js
@@ -143,7 +143,8 @@ module.exports = {
       "@screens": path.resolve(appDirectory, "screens"),
       "@options": path.resolve(appDirectory, "options"),
       "@store": path.resolve(appDirectory, "store"),
-      "@components": path.resolve(appDirectory, "components")
+      "@components": path.resolve(appDirectory, "components"),
+      "@helpers": path.resolve(appDirectory, "helpers")
     },
     // If you're working on a multi-platform React Native app, web-specific
     // module implementations should be written in files using the extension


### PR DESCRIPTION
## Ticket

PLAT-12792

## Type of PR

- [x] New feature

Did you make changes to the scaffold?

- [x] Yes, and have read the [scaffold updates checklist](https://github.com/crowdbotics/react-native-scaffold/#scaffold-updates-checklist) documentation and followed the instructions.
- [ ] No.

## Changes introduced

## 2.6.0 - 2023-11-14

### Added

Added new `helpers` directory and `@helpers` alias on `webpack.config.js` and `metro.config.js`.

The `index.js` includes two new helper hooks for building responsive designs:
- `useComponentLayout` - custom hook for the `onLayout` prop callback - useful for measuring individual elements on resize
- `useMatchMedia` - custom hook that abstracts the `window.matchMedia` Web API

## Test and review

Test the scaffold changes with a module that makes use of it:
```
git clone git@github.com:crowdbotics/modules.git
cd modules
```

Update [--checkout](https://github.com/crowdbotics/modules/blob/ac7acb2b802e263983258f03a4ae091991ea411e/scripts/demo.js#L26) flag to point to this branch `feature/helpers-alias`.

And continue with:
```
npx crowdbotics/modules demo
npx crowdbotics/modules add react-native-styling-patterns
cd demo
yarn run web
```

