### PR TITLE
stop git from ignoring the root `yarn.lock`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Based on [Common Changelog](https://common-changelog.org/).
 
+## 2.6.2 - 2023-11-28
+
+### Fixed
+
+Prevent the root `yarn.lock` file from being gitignored (negate pattern).
+
 ## 2.6.1 - 2023-11-23
 
 ### Fixed

--- a/dist/cookie/{{cookiecutter.project_slug}}/.crowdbotics.json
+++ b/dist/cookie/{{cookiecutter.project_slug}}/.crowdbotics.json
@@ -1,7 +1,7 @@
 {
   "scaffold": {
     "type": "react-native",
-    "version": "2.6.1",
+    "version": "2.6.2",
     "cookiecutter_context": {
       "project_name": "{{cookiecutter.project_name}}",
       "project_slug": "{{cookiecutter.project_slug}}",

--- a/dist/cookie/{{cookiecutter.project_slug}}/.gitignore
+++ b/dist/cookie/{{cookiecutter.project_slug}}/.gitignore
@@ -40,6 +40,7 @@ node_modules/
 npm-debug.log
 yarn-error.log
 **/**/yarn.lock
+!/yarn.lock
 
 # fastlane
 #

--- a/dist/cookie/{{cookiecutter.project_slug}}/yarn.lock
+++ b/dist/cookie/{{cookiecutter.project_slug}}/yarn.lock
@@ -7179,9 +7179,9 @@ react-native-gradle-plugin@^0.71.17:
   integrity sha512-OXXYgpISEqERwjSlaCiaQY6cTY5CH6j73gdkWpK0hedxtiWMWgH+i5TOi4hIGYitm9kQBeyDu+wim9fA8ROFJA==
 
 react-native-paper@^5.9.1:
-  version "5.11.2"
-  resolved "https://registry.yarnpkg.com/react-native-paper/-/react-native-paper-5.11.2.tgz#447b7cae8eaf578e6133ca8f56131b78f4c3cfa1"
-  integrity sha512-UbMkoGtOzU2T54b1uUnqc6YA0kz5mCUxoA4VLcePHDAi/Nvk54gm/TkZnP6nImUMjpcSBI4Fj0GI1cx9Cp169w==
+  version "5.11.3"
+  resolved "https://registry.yarnpkg.com/react-native-paper/-/react-native-paper-5.11.3.tgz#09efd215ed3f6607dec7c76897358a754c2484b7"
+  integrity sha512-550W/B+2LdFt0wBucQQI7GKZJ4XD0DTJz1BxalMv87l8WKKdRrdxI8t1lTEbyFb4gsTHA/sqMVXpQXITh0yplw==
   dependencies:
     "@callstack/react-theme-provider" "^3.0.9"
     color "^3.1.2"

--- a/scaffold/package.json
+++ b/scaffold/package.json
@@ -1,6 +1,6 @@
 {
   "name": "template",
   "description": "React Native Template",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "author": "Crowdbotics"
 }

--- a/scaffold/template/custom/.crowdbotics.json
+++ b/scaffold/template/custom/.crowdbotics.json
@@ -1,7 +1,7 @@
 {
   "scaffold": {
     "type": "react-native",
-    "version": "2.6.1",
+    "version": "2.6.2",
     "cookiecutter_context": {
       "project_name": "{{cookiecutter.project_name}}",
       "project_slug": "{{cookiecutter.project_slug}}",

--- a/scaffold/template/custom/.gitignore
+++ b/scaffold/template/custom/.gitignore
@@ -40,6 +40,7 @@ node_modules/
 npm-debug.log
 yarn-error.log
 **/**/yarn.lock
+!/yarn.lock
 
 # fastlane
 #


### PR DESCRIPTION
## Type of PR

- [x] Bugfix

Did you make changes to the scaffold?

- [x] Yes, and have read the [scaffold updates checklist](https://github.com/crowdbotics/react-native-scaffold/#scaffold-updates-checklist) documentation and followed the instructions.

## Changes introduced

Add `!yarn.lock` to the scaffold's `.gitignore`. Prevents `git` from ignoring the user's root `yarn.lock` file.
