### PR TITLE
PLAT-13561 - fix aliased directories imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 Based on [Common Changelog](https://common-changelog.org/).
 
+## 2.6.3 - 2024-01-18
+
+### Fixed
+
+Fixed the issue preventing imports from aliased directories from working.
+
+Example:
+```js
+import { something } from "@components/some-component";
+```
+
+Would error out with:
+>error: Error: Unable to resolve module @components/some-component from /home/user/your-project/file.js: @components/some-component could not be found within the project or in these directories:
+>  node_modules
+>  ../node_modules
+>  ../../../../node_modules
+
 ## 2.6.2 - 2023-11-28
 
 ### Fixed

--- a/dist/cookie/{{cookiecutter.project_slug}}/.crowdbotics.json
+++ b/dist/cookie/{{cookiecutter.project_slug}}/.crowdbotics.json
@@ -1,7 +1,7 @@
 {
   "scaffold": {
     "type": "react-native",
-    "version": "2.6.2",
+    "version": "2.6.3",
     "cookiecutter_context": {
       "project_name": "{{cookiecutter.project_name}}",
       "project_slug": "{{cookiecutter.project_slug}}",

--- a/dist/cookie/{{cookiecutter.project_slug}}/yarn.lock
+++ b/dist/cookie/{{cookiecutter.project_slug}}/yarn.lock
@@ -7179,9 +7179,9 @@ react-native-gradle-plugin@^0.71.17:
   integrity sha512-OXXYgpISEqERwjSlaCiaQY6cTY5CH6j73gdkWpK0hedxtiWMWgH+i5TOi4hIGYitm9kQBeyDu+wim9fA8ROFJA==
 
 react-native-paper@^5.9.1:
-  version "5.11.3"
-  resolved "https://registry.yarnpkg.com/react-native-paper/-/react-native-paper-5.11.3.tgz#09efd215ed3f6607dec7c76897358a754c2484b7"
-  integrity sha512-550W/B+2LdFt0wBucQQI7GKZJ4XD0DTJz1BxalMv87l8WKKdRrdxI8t1lTEbyFb4gsTHA/sqMVXpQXITh0yplw==
+  version "5.12.1"
+  resolved "https://registry.yarnpkg.com/react-native-paper/-/react-native-paper-5.12.1.tgz#0c3211f78b4d29a110aa168e6541cfb0a2c6a071"
+  integrity sha512-6ZBBJBsHxXUG5mD22Q0tArTlk5GpGlhZDkRU1RRqPtTpxWCMc7Dbc04pU3+qG0peJQCAO6GnXqUbkZ0YLnMPNg==
   dependencies:
     "@callstack/react-theme-provider" "^3.0.9"
     color "^3.1.2"

--- a/scaffold/package.json
+++ b/scaffold/package.json
@@ -1,6 +1,6 @@
 {
   "name": "template",
   "description": "React Native Template",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "author": "Crowdbotics"
 }

--- a/scaffold/template/custom/.crowdbotics.json
+++ b/scaffold/template/custom/.crowdbotics.json
@@ -1,7 +1,7 @@
 {
   "scaffold": {
     "type": "react-native",
-    "version": "2.6.2",
+    "version": "2.6.3",
     "cookiecutter_context": {
       "project_name": "{{cookiecutter.project_name}}",
       "project_slug": "{{cookiecutter.project_slug}}",


### PR DESCRIPTION
## Ticket

PLAT-13561

## Type of PR

- Bugfix

Did you make changes to the scaffold?

- Yes, and have read the [scaffold updates checklist](https://github.com/crowdbotics/react-native-scaffold/#scaffold-updates-checklist) documentation and followed the instructions.

## Changes introduced

Example:
```import from "@components/sub-path" works```

cf8f7ce had broken this feature with the removal of package.json

## Test and review

Update your `crowdbotics/modules/scripts/demo.js` cookiecutter to `checkout` this branch instead of `master`. Create a demo app and `npx react-native start`. Add a `components/index.js` file and test that importing from it works. Then test with `components/sub/index.js`.
