### PR TITLE
fix: bump root package.json to match scaffold version

### DIFF
--- a/scaffold/package.json
+++ b/scaffold/package.json
@@ -1,6 +1,6 @@
 {
   "name": "template",
   "description": "React Native Template",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "author": "Crowdbotics"
 }


### PR DESCRIPTION
## Ticket

PLAT-XXXX
_Related tickets:_
_Related PRs:_

## Type of PR

- [x] Bugfix
- [ ] New feature
- [ ] Minor changes

Did you make changes to the scaffold?

- [ ] Yes, and have read the [scaffold updates checklist](https://github.com/crowdbotics/react-native-scaffold/#scaffold-updates-checklist) documentation and followed the instructions.
- [x] No.

## Changes introduced
yarn semver was failing. the scaffold version of `.crowdbotics.json` must match the root `package.json` version 

## Test and review
CI check for semver must pass