### PR TITLE
chore(circleci): remove _JAVA_OPTIONS from Android config to simplify…

### DIFF
--- a/dist/cookie/{{cookiecutter.project_slug}}/.circleci/generate_mobile_android_config.sh
+++ b/dist/cookie/{{cookiecutter.project_slug}}/.circleci/generate_mobile_android_config.sh
@@ -69,7 +69,6 @@ jobs:
     environment:
       - TERM: "dumb"
       - ADB_INSTALL_TIMEOUT: 10
-      - _JAVA_OPTIONS: "-XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport"
       - GRADLE_OPTS: '-Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-XX:+HeapDumpOnOutOfMemoryError"'
       - BUILD_THREADS: 2
     steps:
@@ -124,7 +123,6 @@ jobs:
     environment:
       - TERM: "dumb"
       - ADB_INSTALL_TIMEOUT: 10
-      - _JAVA_OPTIONS: "-XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport"
       - GRADLE_OPTS: '-Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-XX:+HeapDumpOnOutOfMemoryError"'
       - BUILD_THREADS: 2
     steps:

--- a/dist/cookie/{{cookiecutter.project_slug}}/.crowdbotics.json
+++ b/dist/cookie/{{cookiecutter.project_slug}}/.crowdbotics.json
@@ -1,7 +1,7 @@
 {
   "scaffold": {
     "type": "react-native",
-    "version": "2.7.3",
+    "version": "2.7.4",
     "cookiecutter_context": {
       "project_name": "{{cookiecutter.project_name}}",
       "project_slug": "{{cookiecutter.project_slug}}",

--- a/dist/cookie/{{cookiecutter.project_slug}}/yarn.lock
+++ b/dist/cookie/{{cookiecutter.project_slug}}/yarn.lock
@@ -3959,9 +3959,9 @@ electron-to-chromium@^1.4.284:
   integrity sha512-xZ0y4zjWZgp65okzwwt00f2rYibkFPHUv9qBz+Vzn8cB9UXIo9Zc6Dw81LJYhhNt0G/vR1OJEfStZ49NKl0YxQ==
 
 electron-to-chromium@^1.5.28:
-  version "1.5.31"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.31.tgz#b1478418769dec72ea70d9fdf147a81491857f10"
-  integrity sha512-QcDoBbQeYt0+3CWcK/rEbuHvwpbT/8SV9T3OSgs6cX1FlcUAkgrkqbg9zLnDrMM/rLamzQwal4LYFCiWk861Tg==
+  version "1.5.32"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.32.tgz#4a05ee78e29e240aabaf73a67ce9fe73f52e1bc7"
+  integrity sha512-M+7ph0VGBQqqpTT2YrabjNKSQ2fEl9PVx6AK3N558gDH9NO8O6XN9SXXFWRo9u9PbEg/bWq+tjXQr+eXmxubCw==
 
 emittery@^0.13.1:
   version "0.13.1"

--- a/scaffold/package.json
+++ b/scaffold/package.json
@@ -1,6 +1,6 @@
 {
   "name": "template",
   "description": "React Native Template",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "author": "Crowdbotics"
 }

--- a/scaffold/template/custom/.circleci/generate_mobile_android_config.sh
+++ b/scaffold/template/custom/.circleci/generate_mobile_android_config.sh
@@ -69,7 +69,6 @@ jobs:
     environment:
       - TERM: "dumb"
       - ADB_INSTALL_TIMEOUT: 10
-      - _JAVA_OPTIONS: "-XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport"
       - GRADLE_OPTS: '-Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-XX:+HeapDumpOnOutOfMemoryError"'
       - BUILD_THREADS: 2
     steps:
@@ -124,7 +123,6 @@ jobs:
     environment:
       - TERM: "dumb"
       - ADB_INSTALL_TIMEOUT: 10
-      - _JAVA_OPTIONS: "-XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport"
       - GRADLE_OPTS: '-Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-XX:+HeapDumpOnOutOfMemoryError"'
       - BUILD_THREADS: 2
     steps:


### PR DESCRIPTION
… environment setup

The _JAVA_OPTIONS environment variable is removed as it is no longer necessary for the build process. This change simplifies the configuration and reduces potential conflicts with Java options.

chore(dependencies): bump react-native template version to 2.7.4 The version of the React Native template is updated from 2.7.3 to 2.7.4 to incorporate the latest improvements and bug fixes. This ensures that the project benefits from the most recent updates and maintains compatibility with the latest tools and libraries.

## Ticket

PLAT-XXXX
_Related tickets:_
_Related PRs:_

## Type of PR

- [ ] Bugfix
- [ ] New feature
- [ ] Minor changes

Did you make changes to the scaffold?

- [ ] Yes, and have read the [scaffold updates checklist](https://github.com/crowdbotics/react-native-scaffold/#scaffold-updates-checklist) documentation and followed the instructions.
- [ ] No.

## Changes introduced

_Describe the changes being introduced in this PR_
_Include screenshots if necessary_
_Please link any documentation reference that relate to the changes_

## Test and review

_Describe how a reviewer should test your PR_
